### PR TITLE
feat: allow editing workspace details

### DIFF
--- a/apps/api/src/routes/workspaces/index.test.ts
+++ b/apps/api/src/routes/workspaces/index.test.ts
@@ -5,14 +5,15 @@ import { auth } from '../../lib/auth.js';
 import { workspaceRoutes } from './index.js';
 
 vi.mock('../../lib/auth.js', () => ({
-	auth: {
-		api: {
-			listOrganizations: vi.fn(),
-			createOrganization: vi.fn(),
-			checkOrganizationSlug: vi.fn(),
-			setActiveOrganization: vi.fn(),
-		},
-	},
+        auth: {
+                api: {
+                        listOrganizations: vi.fn(),
+                        createOrganization: vi.fn(),
+                        checkOrganizationSlug: vi.fn(),
+                        updateOrganization: vi.fn(),
+                        setActiveOrganization: vi.fn(),
+                },
+        },
 }));
 
 describe('workspaceRoutes', () => {

--- a/apps/api/src/routes/workspaces/index.ts
+++ b/apps/api/src/routes/workspaces/index.ts
@@ -1,9 +1,12 @@
 import { APIError } from 'better-auth/api';
+import { sql } from 'drizzle-orm';
 import { FastifyInstance } from 'fastify';
 
 import { auth } from '../../lib/auth.js';
 import { validateWorkspaceAccess } from '../../middleware/workspace-access.js';
-import { createWorkspaceSchema } from '../../schemas/workspace.js';
+import { createWorkspaceSchema, updateWorkspaceSchema } from '../../schemas/workspace.js';
+import { db } from '../../db/connection.js';
+import { organization } from '../../db/schema.js';
 import { deleteWorkspace } from '../../services/workspace.js';
 import '../../types/fastify.js';
 import { AppError, getErrorMessage } from '../../utils/error.js';
@@ -29,11 +32,163 @@ export async function workspaceRoutes(fastify: FastifyInstance) {
 		prefix: '/:workspaceId/members',
 	});
 
-	fastify.addHook('preHandler', fastify.authenticate);
+        fastify.addHook('preHandler', fastify.authenticate);
 
-	fastify.delete(
-		'/:workspaceId',
-		{ preHandler: [validateWorkspaceAccess] },
+        fastify.patch(
+                '/:workspaceId',
+                { preHandler: [validateWorkspaceAccess] },
+                async (request, reply) => {
+                        try {
+                                const { workspaceId } = request.params as { workspaceId: string };
+                                const body = updateWorkspaceSchema.parse(request.body);
+
+                                if (!body.name && !body.slug && !body.logo && !body.metadata) {
+                                        return reply.status(400).send({
+                                                success: false,
+                                                error: {
+                                                        code: 'NO_WORKSPACE_UPDATES',
+                                                        message: 'Please provide at least one field to update.',
+                                                },
+                                        });
+                                }
+
+                                const updates: Record<string, unknown> = {};
+
+                                if (body.name) {
+                                        const trimmedName = body.name.trim();
+                                        const currentName = request.workspace?.name || '';
+
+                                        if (trimmedName.length === 0) {
+                                                return reply.status(400).send({
+                                                        success: false,
+                                                        error: {
+                                                                code: 'INVALID_WORKSPACE_NAME',
+                                                                message: 'Workspace name is required.',
+                                                        },
+                                                });
+                                        }
+
+                                        if (trimmedName.toLowerCase() !== currentName.toLowerCase()) {
+                                                const [existing] = await db
+                                                        .select({ id: organization.id })
+                                                        .from(organization)
+                                                        .where(
+                                                                sql`LOWER(${organization.name}) = LOWER(${trimmedName}) AND ${organization.id} <> ${workspaceId}`,
+                                                        )
+                                                        .limit(1);
+
+                                                if (existing) {
+                                                        return reply.status(409).send({
+                                                                success: false,
+                                                                error: {
+                                                                        code: 'WORKSPACE_NAME_TAKEN',
+                                                                        message: 'This workspace name is already in use.',
+                                                                },
+                                                        });
+                                                }
+                                        }
+
+                                        updates.name = trimmedName;
+                                }
+
+                                if (body.slug) {
+                                        const trimmedSlug = body.slug.trim();
+                                        const currentSlug = request.workspace?.slug || '';
+
+                                        if (trimmedSlug.length === 0) {
+                                                return reply.status(400).send({
+                                                        success: false,
+                                                        error: {
+                                                                code: 'INVALID_WORKSPACE_SLUG',
+                                                                message: 'Workspace slug is required.',
+                                                        },
+                                                });
+                                        }
+
+                                        if (trimmedSlug !== currentSlug) {
+                                                try {
+                                                        const result = await auth.api.checkOrganizationSlug({
+                                                                body: { slug: trimmedSlug },
+                                                        });
+
+                                                        if (!result.status) {
+                                                                return reply.status(409).send({
+                                                                        success: false,
+                                                                        error: {
+                                                                                code: 'WORKSPACE_SLUG_TAKEN',
+                                                                                message: 'This workspace URL is already taken.',
+                                                                        },
+                                                                });
+                                                        }
+                                                } catch (error) {
+                                                        if (
+                                                                error instanceof APIError &&
+                                                                error?.body?.code === 'SLUG_IS_TAKEN'
+                                                        ) {
+                                                                return reply.status(409).send({
+                                                                        success: false,
+                                                                        error: {
+                                                                                code: 'WORKSPACE_SLUG_TAKEN',
+                                                                                message: 'This workspace URL is already taken.',
+                                                                        },
+                                                                });
+                                                        }
+
+                                                        throw error;
+                                                }
+                                        }
+
+                                        updates.slug = trimmedSlug;
+                                }
+
+                                if (body.logo) {
+                                        updates.logo = body.logo;
+                                }
+
+                                if (body.metadata) {
+                                        updates.metadata = body.metadata;
+                                }
+
+                                const result = await auth.api.updateOrganization({
+                                        body: {
+                                                organizationId: workspaceId,
+                                                data: updates,
+                                        },
+                                        headers: request.headers as any,
+                                });
+
+                                return reply.send({
+                                        success: true,
+                                        data: result,
+                                });
+                        } catch (error) {
+                                fastify.log.error(error);
+
+                                if (error instanceof APIError) {
+                                        const statusCode = error.status ?? 400;
+                                        return reply.status(statusCode).send({
+                                                success: false,
+                                                error: {
+                                                        code: error.body?.code || 'FAILED_TO_UPDATE_WORKSPACE',
+                                                        message: getErrorMessage(error, 'Failed to update workspace'),
+                                                },
+                                        });
+                                }
+
+                                return reply.status(500).send({
+                                        success: false,
+                                        error: {
+                                                code: 'FAILED_TO_UPDATE_WORKSPACE',
+                                                message: getErrorMessage(error, 'Failed to update workspace'),
+                                        },
+                                });
+                        }
+                },
+        );
+
+        fastify.delete(
+                '/:workspaceId',
+                { preHandler: [validateWorkspaceAccess] },
 		async (request, reply) => {
 			try {
 				const { workspaceId } = request.params as { workspaceId: string };
@@ -125,12 +280,56 @@ export async function workspaceRoutes(fastify: FastifyInstance) {
 		}
 	});
 
-	fastify.post('/exists', async (request, reply) => {
-		try {
-			const { slug } = request.body as { slug: string };
-			const result = await auth.api.checkOrganizationSlug({
-				body: {
-					slug,
+        fastify.post('/name-exists', async (request, reply) => {
+                try {
+                        const { name, workspaceId } = request.body as {
+                                name?: string;
+                                workspaceId?: string;
+                        };
+
+                        if (!name || name.trim().length === 0) {
+                                return reply.status(400).send({
+                                        success: false,
+                                        error: {
+                                                code: 'WORKSPACE_NAME_REQUIRED',
+                                                message: 'Workspace name is required',
+                                        },
+                                });
+                        }
+
+                        const normalizedName = name.trim();
+                        const condition = workspaceId
+                                ? sql`LOWER(${organization.name}) = LOWER(${normalizedName}) AND ${organization.id} <> ${workspaceId}`
+                                : sql`LOWER(${organization.name}) = LOWER(${normalizedName})`;
+
+                        const [existing] = await db
+                                .select({ id: organization.id })
+                                .from(organization)
+                                .where(condition)
+                                .limit(1);
+
+                        return reply.send({
+                                success: true,
+                                data: { available: !existing },
+                        });
+                } catch (error) {
+                        fastify.log.error(error);
+                        return reply.status(500).send({
+                                success: false,
+                                error: {
+                                        code: 'FAILED_TO_CHECK_WORKSPACE_NAME',
+                                        message: getErrorMessage(error, 'Failed to check workspace name'),
+                                },
+                        });
+                }
+        });
+
+        fastify.post('/exists', async (request, reply) => {
+                try {
+                        const { slug } = request.body as { slug: string };
+                        const result = await auth.api.checkOrganizationSlug({
+                                body: {
+                                        slug,
 				},
 			});
 

--- a/apps/api/src/schemas/workspace.ts
+++ b/apps/api/src/schemas/workspace.ts
@@ -9,9 +9,17 @@ export const createWorkspaceSchema = z.object({
 });
 
 export const updateWorkspaceSchema = z.object({
-	name: z.string().min(1, 'Workspace name is required').optional(),
-	logo: z.string().optional(),
-	metadata: z.record(z.string(), z.string()).optional(),
+        name: z.string().min(1, 'Workspace name is required').optional(),
+        slug: z
+                .string()
+                .min(1, 'Workspace slug is required')
+                .regex(/^[a-z0-9-]+$/, 'Slug can only contain lowercase letters, numbers, and hyphens')
+                .refine((value) => !value.startsWith('-') && !value.endsWith('-'), {
+                        message: 'Slug cannot start or end with a hyphen',
+                })
+                .optional(),
+        logo: z.string().optional(),
+        metadata: z.record(z.string(), z.string()).optional(),
 });
 
 export const workspaceWebhookSchema = z.object({

--- a/apps/web/src/api/workspaces.ts
+++ b/apps/web/src/api/workspaces.ts
@@ -29,13 +29,24 @@ export type Workspace = {
 };
 
 export type SlugStatus = {
-	status: boolean;
+        status: boolean;
+};
+
+export type NameAvailabilityStatus = {
+        available: boolean;
+};
+
+export type UpdateWorkspaceRequest = {
+        name?: string;
+        slug?: string;
+        logo?: string;
+        metadata?: Record<string, string>;
 };
 
 interface ConfigurationQuery {
-	page?: number;
-	limit?: number;
-	search?: string;
+        page?: number;
+        limit?: number;
+        search?: string;
 }
 
 export const workspaceApi = {
@@ -98,24 +109,55 @@ export const workspaceApi = {
 		return response.data;
 	},
 
-	isSlugAvailable: async function (slug: string): Promise<boolean> {
-		const response = await api.post<ApiResponse<SlugStatus>>(
-			'/v1/workspace/exists',
-			{
-				slug,
-			},
-		);
-		if (!response.success) {
-			toast.error(response.error.message);
-			return false;
-		}
-		return response.data.status;
-	},
+        isSlugAvailable: async function (slug: string): Promise<boolean> {
+                const response = await api.post<ApiResponse<SlugStatus>>(
+                        '/v1/workspace/exists',
+                        {
+                                slug,
+                        },
+                );
+                if (!response.success) {
+                        toast.error(response.error.message);
+                        return false;
+                }
+                return response.data.status;
+        },
 
-	delete: async function (workspaceId: string): Promise<SuccessResponse<null>> {
-		const response = await api.delete<SuccessResponse<null>>(
-			`/v1/workspace/${workspaceId}`,
-		);
+        isNameAvailable: async function (
+                name: string,
+                workspaceId?: string,
+        ): Promise<boolean> {
+                const response = await api.post<ApiResponse<NameAvailabilityStatus>>(
+                        '/v1/workspace/name-exists',
+                        {
+                                name,
+                                workspaceId,
+                        },
+                );
+
+                if (!response.success) {
+                        toast.error(response.error.message);
+                        return false;
+                }
+
+                return response.data.available;
+        },
+
+        update: async function (
+                workspaceId: string,
+                data: UpdateWorkspaceRequest,
+        ): Promise<Workspace> {
+                const response = await api.patch<SuccessResponse<Workspace>>(
+                        `/v1/workspace/${workspaceId}`,
+                        data,
+                );
+                return response.data;
+        },
+
+        delete: async function (workspaceId: string): Promise<SuccessResponse<null>> {
+                const response = await api.delete<SuccessResponse<null>>(
+                        `/v1/workspace/${workspaceId}`,
+                );
 		return response;
 	},
 };

--- a/apps/web/src/components/settings/workspace-details-form.tsx
+++ b/apps/web/src/components/settings/workspace-details-form.tsx
@@ -1,0 +1,302 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+import {
+        useCheckSlugExists,
+        useCheckWorkspaceName,
+        useUpdateWorkspace,
+} from '@/hooks/use-workspaces';
+import { useWorkspaceStore } from '@/stores/workspace-store';
+
+import { Button } from '../ui/button';
+import {
+        Card,
+        CardContent,
+        CardDescription,
+        CardHeader,
+        CardTitle,
+} from '../ui/card';
+import {
+        Form,
+        FormControl,
+        FormField,
+        FormItem,
+        FormLabel,
+        FormMessage,
+} from '../ui/form';
+import { Input } from '../ui/input';
+
+const formSchema = z.object({
+        name: z.string().min(1, 'Workspace name is required'),
+        slug: z
+                .string()
+                .min(1, 'Workspace slug is required')
+                .regex(/^[a-z0-9-]+$/, 'Slug can only contain lowercase letters, numbers, and hyphens')
+                .refine((value) => !value.startsWith('-') && !value.endsWith('-'), {
+                        message: 'Slug cannot start or end with a hyphen',
+                }),
+});
+
+type FormData = z.infer<typeof formSchema>;
+
+export function WorkspaceDetailsForm() {
+        const { activeWorkspace, isLoading } = useWorkspaceStore((state) => ({
+                activeWorkspace: state.activeWorkspace,
+                isLoading: state.isLoading,
+        }));
+        const updateWorkspace = useUpdateWorkspace();
+        const checkSlugExists = useCheckSlugExists();
+        const checkWorkspaceName = useCheckWorkspaceName();
+
+        const form = useForm<FormData>({
+                resolver: zodResolver(formSchema),
+                defaultValues: {
+                        name: activeWorkspace?.name ?? '',
+                        slug: activeWorkspace?.slug ?? '',
+                },
+        });
+
+        const slugValue = form.watch('slug');
+        const nameValue = form.watch('name');
+        const trimmedNameValue = nameValue?.trim() ?? '';
+        const trimmedSlugValue = slugValue?.trim() ?? '';
+
+        useEffect(() => {
+                form.reset({
+                        name: activeWorkspace?.name ?? '',
+                        slug: activeWorkspace?.slug ?? '',
+                });
+                checkSlugExists.reset();
+                checkWorkspaceName.reset();
+        }, [activeWorkspace, form, checkSlugExists, checkWorkspaceName]);
+
+        useEffect(() => {
+                if (!activeWorkspace) {
+                        return;
+                }
+
+                const trimmedName = trimmedNameValue;
+
+                if (trimmedName.length === 0) {
+                        checkWorkspaceName.reset();
+                        return;
+                }
+
+                if (trimmedName.toLowerCase() === activeWorkspace.name.toLowerCase()) {
+                        checkWorkspaceName.reset();
+                        form.clearErrors('name');
+                        return;
+                }
+
+                const timeoutId = window.setTimeout(async () => {
+                        try {
+                                const available = await checkWorkspaceName.mutateAsync({
+                                        name: trimmedName,
+                                        workspaceId: activeWorkspace.id,
+                                });
+
+                                if (!available) {
+                                        form.setError('name', {
+                                                type: 'manual',
+                                                message: 'This workspace name is already taken',
+                                        });
+                                } else {
+                                        form.clearErrors('name');
+                                }
+                        } catch (error) {
+                                console.error('Failed to check workspace name availability', error);
+                        }
+                }, 400);
+
+                return () => window.clearTimeout(timeoutId);
+        }, [trimmedNameValue, activeWorkspace, checkWorkspaceName, form]);
+
+        useEffect(() => {
+                if (!activeWorkspace) {
+                        return;
+                }
+
+                const trimmedSlug = trimmedSlugValue;
+
+                if (trimmedSlug.length === 0) {
+                        checkSlugExists.reset();
+                        return;
+                }
+
+                if (trimmedSlug === activeWorkspace.slug) {
+                        checkSlugExists.reset();
+                        form.clearErrors('slug');
+                        return;
+                }
+
+                const slugRegex = /^[a-z0-9-]+$/;
+
+                if (!slugRegex.test(trimmedSlug) || trimmedSlug.startsWith('-') || trimmedSlug.endsWith('-')) {
+                        checkSlugExists.reset();
+                        return;
+                }
+
+                const timeoutId = window.setTimeout(async () => {
+                        try {
+                                const available = await checkSlugExists.mutateAsync(trimmedSlug);
+
+                                if (!available) {
+                                        form.setError('slug', {
+                                                type: 'manual',
+                                                message: 'This workspace URL is already taken',
+                                        });
+                                } else {
+                                        form.clearErrors('slug');
+                                }
+                        } catch (error) {
+                                console.error('Failed to check workspace slug availability', error);
+                        }
+                }, 400);
+
+                return () => window.clearTimeout(timeoutId);
+        }, [trimmedSlugValue, activeWorkspace, checkSlugExists, form]);
+
+        async function onSubmit(values: FormData) {
+                if (!activeWorkspace) {
+                        return;
+                }
+
+                const payload: { name?: string; slug?: string } = {};
+                const trimmedName = values.name.trim();
+                const trimmedSlug = values.slug.trim();
+
+                if (trimmedName !== activeWorkspace.name) {
+                        payload.name = trimmedName;
+                }
+
+                if (trimmedSlug !== activeWorkspace.slug) {
+                        payload.slug = trimmedSlug;
+                }
+
+                if (Object.keys(payload).length === 0) {
+                        return;
+                }
+
+                try {
+                        const updatedWorkspace = await updateWorkspace.mutateAsync({
+                                workspaceId: activeWorkspace.id,
+                                data: payload,
+                        });
+
+                        form.reset({
+                                name: updatedWorkspace.name,
+                                slug: updatedWorkspace.slug,
+                        });
+                } catch (error) {
+                        console.error('Failed to update workspace', error);
+                }
+        }
+
+        if (!activeWorkspace) {
+                return (
+                        <Card>
+                                <CardHeader>
+                                        <CardTitle>Workspace details</CardTitle>
+                                        <CardDescription>
+                                                Update your workspace name and URL.
+                                        </CardDescription>
+                                </CardHeader>
+                                <CardContent>
+                                        <p className="text-sm text-muted-foreground">
+                                                {isLoading
+                                                        ? 'Loading workspace information...'
+                                                        : 'Select a workspace to manage its settings.'}
+                                        </p>
+                                </CardContent>
+                        </Card>
+                );
+        }
+
+        const isCheckingAvailability =
+                checkSlugExists.isPending || checkWorkspaceName.isPending;
+
+        return (
+                <Card>
+                        <CardHeader>
+                                <CardTitle>Workspace details</CardTitle>
+                                <CardDescription>
+                                        Update how your workspace appears and the URL your team uses.
+                                </CardDescription>
+                        </CardHeader>
+                        <CardContent>
+                                <Form {...form}>
+                                        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+                                                <FormField
+                                                        control={form.control}
+                                                        name="name"
+                                                        render={({ field }) => (
+                                                                <FormItem>
+                                                                        <FormLabel>Workspace name</FormLabel>
+                                                                        <FormControl>
+                                                                                <Input placeholder="Workspace name" {...field} />
+                                                                        </FormControl>
+                                                                        {!form.formState.errors.name &&
+                                                                                checkWorkspaceName.isSuccess &&
+                                                                                checkWorkspaceName.data &&
+                                                                                trimmedNameValue.length > 0 &&
+                                                                                trimmedNameValue.toLowerCase() !==
+                                                                                        activeWorkspace.name.toLowerCase() && (
+                                                                                        <p className="mt-1 text-sm text-green-600">
+                                                                                                Workspace name is available
+                                                                                        </p>
+                                                                                )}
+                                                                        <FormMessage />
+                                                                </FormItem>
+                                                        )}
+                                                />
+                                                <FormField
+                                                        control={form.control}
+                                                        name="slug"
+                                                        render={({ field }) => (
+                                                                <FormItem>
+                                                                        <FormLabel>Workspace URL</FormLabel>
+                                                                        <FormControl>
+                                                                                <div className="flex">
+                                                                                        <span className="border-input bg-muted text-muted-foreground inline-flex items-center rounded-l-md border border-r-0 px-3 text-sm">
+                                                                                                usemutate.com/
+                                                                                        </span>
+                                                                                        <Input
+                                                                                                {...field}
+                                                                                                placeholder="workspace-url"
+                                                                                                className="rounded-l-none"
+                                                                                        />
+                                                                                </div>
+                                                                        </FormControl>
+                                                                        {!form.formState.errors.slug &&
+                                                                                checkSlugExists.isSuccess &&
+                                                                                checkSlugExists.data &&
+                                                                                trimmedSlugValue.length > 0 &&
+                                                                                trimmedSlugValue !== activeWorkspace.slug && (
+                                                                                        <p className="mt-1 text-sm text-green-600">
+                                                                                                Workspace URL is available
+                                                                                        </p>
+                                                                                )}
+                                                                        <FormMessage />
+                                                                </FormItem>
+                                                        )}
+                                                />
+                                                <div className="flex items-center gap-3">
+                                                        <Button
+                                                                type="submit"
+                                                                disabled={
+                                                                        !form.formState.isDirty ||
+                                                                        updateWorkspace.isPending ||
+                                                                        isCheckingAvailability
+                                                                }
+                                                        >
+                                                                {updateWorkspace.isPending ? 'Saving…' : 'Save changes'}
+                                                        </Button>
+                                                </div>
+                                        </form>
+                                </Form>
+                        </CardContent>
+                </Card>
+        );
+}

--- a/apps/web/src/hooks/use-workspaces.ts
+++ b/apps/web/src/hooks/use-workspaces.ts
@@ -1,15 +1,22 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
 
 import { useSession } from '@/stores/auth-store';
 import { useWorkspaceStore } from '@/stores/workspace-store';
 
 import {
-	type CreateWorkspaceRequest,
-	type Workspace,
-	workspaceApi,
+        type CreateWorkspaceRequest,
+        type UpdateWorkspaceRequest,
+        type Workspace,
+        workspaceApi,
 } from '../api/workspaces';
 
 const queryKey = ['workspaces'];
+
+type CheckWorkspaceNamePayload = {
+        name: string;
+        workspaceId?: string;
+};
 
 export function useCreateWorkspace() {
 	const queryClient = useQueryClient();
@@ -38,7 +45,50 @@ export function useListWorkspace() {
 }
 
 export function useCheckSlugExists() {
-	return useMutation({
-		mutationFn: (slug: string) => workspaceApi.isSlugAvailable(slug),
-	});
+        return useMutation({
+                mutationFn: (slug: string) => workspaceApi.isSlugAvailable(slug),
+        });
+}
+
+export function useCheckWorkspaceName() {
+        return useMutation({
+                mutationFn: ({ name, workspaceId }: CheckWorkspaceNamePayload) =>
+                        workspaceApi.isNameAvailable(name, workspaceId),
+        });
+}
+
+export function useUpdateWorkspace() {
+        const queryClient = useQueryClient();
+
+        return useMutation({
+                mutationFn: ({ workspaceId, data }: { workspaceId: string; data: UpdateWorkspaceRequest }) =>
+                        workspaceApi.update(workspaceId, data),
+                onSuccess: (workspace: Workspace) => {
+                        useWorkspaceStore.setState((state) => {
+                                const workspaces = state.workspaces.some((ws) => ws.id === workspace.id)
+                                        ? state.workspaces.map((ws) =>
+                                                  ws.id === workspace.id ? workspace : ws,
+                                          )
+                                        : [...state.workspaces, workspace];
+
+                                return {
+                                        workspaces,
+                                        activeWorkspace:
+                                                state.activeWorkspace?.id === workspace.id
+                                                        ? workspace
+                                                        : state.activeWorkspace,
+                                };
+                        });
+
+                        queryClient.invalidateQueries({ queryKey });
+                        queryClient.invalidateQueries({
+                                queryKey: [...queryKey, workspace?.id],
+                        });
+
+                        toast.success('Workspace updated successfully');
+                },
+                onError: () => {
+                        toast.error('Failed to update workspace');
+                },
+        });
 }

--- a/apps/web/src/routes/settings/workspace/index.tsx
+++ b/apps/web/src/routes/settings/workspace/index.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from '@tanstack/react-router';
 
 import { DeleteWorkspace } from '@/components/settings/delete-workspace';
 import { SettingsHeader } from '@/components/settings/header';
+import { WorkspaceDetailsForm } from '@/components/settings/workspace-details-form';
 import { Card, CardContent } from '@/components/ui/card';
 
 export const Route = createFileRoute('/settings/workspace/')({
@@ -10,16 +11,18 @@ export const Route = createFileRoute('/settings/workspace/')({
 
 export function RouteComponent() {
 	return (
-		<div className="space-y-6">
-			<SettingsHeader
-				title="Workspace"
-				description="Manage your workspace settings."
-			/>
+                <div className="space-y-6">
+                        <SettingsHeader
+                                title="Workspace"
+                                description="Manage your workspace settings."
+                        />
 
-			<Card className="border-destructive">
-				<CardContent>
-					<DeleteWorkspace />
-				</CardContent>
+                        <WorkspaceDetailsForm />
+
+                        <Card className="border-destructive">
+                                <CardContent>
+                                        <DeleteWorkspace />
+                                </CardContent>
 			</Card>
 		</div>
 	);


### PR DESCRIPTION
## Summary
- add API endpoint to update workspace metadata with slug and name validation
- expose workspace name availability checks and update helper on the frontend
- add workspace settings form so users can update workspace name and slug from the UI

## Testing
- pnpm --filter @mutate/web lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d68ddc510c8332826238dd64db1b1e